### PR TITLE
Dep Variant: List Twice (HDF5)

### DIFF
--- a/.ci_support/linux_mpimpichpython3.6target_platformlinux-64.yaml
+++ b/.ci_support/linux_mpimpichpython3.6target_platformlinux-64.yaml
@@ -20,6 +20,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libffi:
 - '3.2'
 libpng:

--- a/.ci_support/linux_mpimpichpython3.7target_platformlinux-64.yaml
+++ b/.ci_support/linux_mpimpichpython3.7target_platformlinux-64.yaml
@@ -20,6 +20,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libffi:
 - '3.2'
 libpng:

--- a/.ci_support/linux_mpinompipython3.6target_platformlinux-64.yaml
+++ b/.ci_support/linux_mpinompipython3.6target_platformlinux-64.yaml
@@ -20,6 +20,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libffi:
 - '3.2'
 libpng:

--- a/.ci_support/linux_mpinompipython3.7target_platformlinux-64.yaml
+++ b/.ci_support/linux_mpinompipython3.7target_platformlinux-64.yaml
@@ -20,6 +20,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libffi:
 - '3.2'
 libpng:

--- a/.ci_support/linux_mpiopenmpipython3.6target_platformlinux-64.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.6target_platformlinux-64.yaml
@@ -20,6 +20,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libffi:
 - '3.2'
 libpng:

--- a/.ci_support/linux_mpiopenmpipython3.7target_platformlinux-64.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.7target_platformlinux-64.yaml
@@ -20,6 +20,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libffi:
 - '3.2'
 libpng:

--- a/.ci_support/osx_mpimpichpython3.6target_platformosx-64.yaml
+++ b/.ci_support/osx_mpimpichpython3.6target_platformosx-64.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '4'
+hdf5:
+- 1.10.5
 libffi:
 - '3.2'
 libpng:

--- a/.ci_support/osx_mpimpichpython3.7target_platformosx-64.yaml
+++ b/.ci_support/osx_mpimpichpython3.7target_platformosx-64.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '4'
+hdf5:
+- 1.10.5
 libffi:
 - '3.2'
 libpng:

--- a/.ci_support/osx_mpinompipython3.6target_platformosx-64.yaml
+++ b/.ci_support/osx_mpinompipython3.6target_platformosx-64.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '4'
+hdf5:
+- 1.10.5
 libffi:
 - '3.2'
 libpng:

--- a/.ci_support/osx_mpinompipython3.7target_platformosx-64.yaml
+++ b/.ci_support/osx_mpinompipython3.7target_platformosx-64.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '4'
+hdf5:
+- 1.10.5
 libffi:
 - '3.2'
 libpng:

--- a/.ci_support/osx_mpiopenmpipython3.6target_platformosx-64.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.6target_platformosx-64.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '4'
+hdf5:
+- 1.10.5
 libffi:
 - '3.2'
 libpng:

--- a/.ci_support/osx_mpiopenmpipython3.7target_platformosx-64.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.7target_platformosx-64.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '4'
+hdf5:
+- 1.10.5
 libffi:
 - '3.2'
 libpng:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "adios2" %}
 {% set version = "2.4.0" %}
-{% set build = 3 %}
+{% set build = 4 %}
 {% set sha256 = "50ecea04b1e41c88835b4b3fd4e7bf0a0a2a3129855c9cc4ba6cf6a1575106e2" %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
@@ -62,6 +62,9 @@ requirements:
     - numpy >=1.15.0
     - libffi
     # TODO: missing linker symbols on Windows
+    # need to list hdf5 twice to get version pinning from conda_build_config
+    # and build pinning from {{ mpi_prefix }}
+    - hdf5                                 # [not win]
     - hdf5  >=1.8.13 = {{ mpi_prefix }}_*  # [not win]
     # TODO: Could NOT find ZeroMQ (missing: ZeroMQ_LIBRARY) on Windows
     - zeromq >=4.1  # [not win]
@@ -72,7 +75,6 @@ requirements:
   run:
     - {{ mpi }}  # [mpi != 'nompi']
     - mpi4py     # [mpi != 'nompi']
-    - hdf5  >=1.8.13 = {{ mpi_prefix }}_*  # [not win]
     - python
     - numpy >=1.15.0
 


### PR DESCRIPTION
need to list hdf5 twice to get version pinning from `conda_build_config` and build pinning from `{{ mpi_prefix }}`

See https://github.com/conda-forge/h5py-feedstock/pull/57

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase @conda-forge-admin, please rerender in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
