### PR TITLE
Patch: DataMan/GCC10 & CXX20

### DIFF
--- a/recipe/002-PR3145-cxx20.patch
+++ b/recipe/002-PR3145-cxx20.patch
@@ -1,0 +1,60 @@
+From 51561aab5a005bf3fcac3b765c4e203668c65105 Mon Sep 17 00:00:00 2001
+From: "Garth N. Wells" <gnw20@cam.ac.uk>
+Date: Fri, 1 Apr 2022 08:36:42 +0100
+Subject: [PATCH] Syntax fix in declarations.
+
+---
+ bindings/CXX11/adios2/cxx11/Attribute.h | 6 +++---
+ bindings/CXX11/adios2/cxx11/Variable.h  | 6 +++---
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/bindings/CXX11/adios2/cxx11/Attribute.h b/bindings/CXX11/adios2/cxx11/Attribute.h
+index fd55ab0b5..931a3c7d4 100644
+--- a/bindings/CXX11/adios2/cxx11/Attribute.h
++++ b/bindings/CXX11/adios2/cxx11/Attribute.h
+@@ -43,8 +43,8 @@ class Attribute
+      * attributes from IO:DefineAttribute<T> or IO:InquireAttribute<T>.
+      * Can be used with STL containers.
+      */
+-    Attribute<T>() = default;
+-    ~Attribute<T>() = default;
++    Attribute() = default;
++    ~Attribute() = default;
+ 
+     /** Checks if object is valid, e.g. if( attribute ) { //..valid } */
+     explicit operator bool() const noexcept;
+@@ -74,7 +74,7 @@ class Attribute
+     bool IsValue() const;
+ 
+ private:
+-    Attribute<T>(core::Attribute<IOType> *attribute);
++    Attribute(core::Attribute<IOType> *attribute);
+     core::Attribute<IOType> *m_Attribute = nullptr;
+ };
+ 
+diff --git a/bindings/CXX11/adios2/cxx11/Variable.h b/bindings/CXX11/adios2/cxx11/Variable.h
+index 9cce77c77..4d26281e2 100644
+--- a/bindings/CXX11/adios2/cxx11/Variable.h
++++ b/bindings/CXX11/adios2/cxx11/Variable.h
+@@ -141,10 +141,10 @@ class Variable
+      * variables from IO:DefineVariable<T> or IO:InquireVariable<T>.
+      * Can be used with STL containers.
+      */
+-    Variable<T>() = default;
++    Variable() = default;
+ 
+     /** Default, using RAII STL containers */
+-    ~Variable<T>() = default;
++    ~Variable() = default;
+ 
+     /** Checks if object is valid, e.g. if( variable ) { //..valid } */
+     explicit operator bool() const noexcept;
+@@ -389,7 +389,7 @@ class Variable
+     using Span = adios2::detail::Span<T>;
+ 
+ private:
+-    Variable<T>(core::Variable<IOType> *variable);
++    Variable(core::Variable<IOType> *variable);
+     core::Variable<IOType> *m_Variable = nullptr;
+ 
+     std::vector<std::vector<typename Variable<T>::Info>> DoAllStepsBlocksInfo();

--- a/recipe/003-PR3155-gcc10-dataman.patch
+++ b/recipe/003-PR3155-gcc10-dataman.patch
@@ -1,0 +1,78 @@
+From 6814f2f6248d22b1fdf78b46ad0a7f97a7087a65 Mon Sep 17 00:00:00 2001
+From: Jason Wang <jason.ruonan.wang@gmail.com>
+Date: Sat, 2 Apr 2022 17:12:40 -0400
+Subject: [PATCH 1/2] only build dataspaces when MPI is found
+
+---
+ cmake/DetectOptions.cmake | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/cmake/DetectOptions.cmake b/cmake/DetectOptions.cmake
+index aa5159e6e..d4e2e5dbf 100644
+--- a/cmake/DetectOptions.cmake
++++ b/cmake/DetectOptions.cmake
+@@ -255,13 +255,15 @@ elseif(ADIOS2_USE_MHS)
+ endif()
+ 
+ # DataSpaces
+-if(ADIOS2_USE_DataSpaces STREQUAL AUTO)
+-  find_package(DataSpaces 2.1.1)
+-elseif(ADIOS2_USE_DataSpaces)
+-  find_package(DataSpaces 2.1.1 REQUIRED)
+-endif()
+-if(DATASPACES_FOUND)
+-  set(ADIOS2_HAVE_DataSpaces TRUE)
++if(MPI_FOUND)
++    if(ADIOS2_USE_DataSpaces STREQUAL AUTO)
++        find_package(DataSpaces 2.1.1)
++    elseif(ADIOS2_USE_DataSpaces)
++        find_package(DataSpaces 2.1.1 REQUIRED)
++    endif()
++    if(DATASPACES_FOUND)
++        set(ADIOS2_HAVE_DataSpaces TRUE)
++    endif()
+ endif()
+ 
+ # HDF5
+
+From 63e5d6c0e3f3cb78350bc87f3193de88241c3b26 Mon Sep 17 00:00:00 2001
+From: Jason Wang <jason.ruonan.wang@gmail.com>
+Date: Sun, 3 Apr 2022 21:16:00 -0400
+Subject: [PATCH 2/2] fix template instantiation bug in DataMan serializer
+
+---
+ .../adios2/toolkit/format/dataman/DataManSerializer.cpp   | 1 -
+ source/adios2/toolkit/format/dataman/DataManSerializer.h  | 8 ++++++++
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+index e343fb76f..e6e20fdb1 100644
+--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
++++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+@@ -622,7 +622,6 @@ void DataManSerializer::Log(const int level, const std::string &message,
+     }
+ }
+ 
+-template <>
+ void DataManSerializer::PutData(
+     const std::string *inputData, const std::string &varName,
+     const Dims &varShape, const Dims &varStart, const Dims &varCount,
+diff --git a/source/adios2/toolkit/format/dataman/DataManSerializer.h b/source/adios2/toolkit/format/dataman/DataManSerializer.h
+index 65e4b430a..44647ccbd 100644
+--- a/source/adios2/toolkit/format/dataman/DataManSerializer.h
++++ b/source/adios2/toolkit/format/dataman/DataManSerializer.h
+@@ -93,6 +93,14 @@ class DataManSerializer
+     void PutAttributes(core::IO &io);
+ 
+     // put a variable for writer
++    void PutData(const std::string *inputData, const std::string &varName,
++                 const Dims &varShape, const Dims &varStart,
++                 const Dims &varCount, const Dims &varMemStart,
++                 const Dims &varMemCount, const std::string &doid,
++                 const size_t step, const int rank, const std::string &address,
++                 const std::vector<std::shared_ptr<core::Operator>> &ops,
++                 VecPtr localBuffer = nullptr, JsonPtr metadataJson = nullptr);
++
+     template <class T>
+     void PutData(const T *inputData, const std::string &varName,
+                  const Dims &varShape, const Dims &varStart,

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -86,7 +86,6 @@ cmake --build build -j${CPU_COUNT}
 if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" && "${RUN_TESTS}" == "ON" ]]
 then
     # SST: Flaky tests
-    # DataMan in 2.8.0: see https://github.com/ornladios/ADIOS2/issues/3151
-    ctest --test-dir build --output-on-failure -E "SST|DataManEngineTest.1D.Serial"
+    ctest --test-dir build --output-on-failure -E "SST"
 fi
 cmake --build build --target install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "adios2" %}
 {% set version = "2.8.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set sha256 = "5af3d950e616989133955c2430bd09bcf6bad3a04cf62317b401eaf6e7c2d479" %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
@@ -21,6 +21,12 @@ source:
   patches:
     # https://github.com/ornladios/ADIOS2/pull/3153
     - 001-PR3153-win-msvc-enum.patch
+    # https://github.com/ornladios/ADIOS2/issues/3146
+    # https://github.com/ornladios/ADIOS2/pull/3145
+    - 002-PR3145-cxx20.patch
+    # https://github.com/ornladios/ADIOS2/issues/3151
+    # https://github.com/ornladios/ADIOS2/pull/3155
+    - 003-PR3155-gcc10-dataman.patch
 
 build:
   number: {{ build }}


### PR DESCRIPTION
Apply more post-2.8.0 patches.

- CXX20 downstream fix: https://github.com/ornladios/ADIOS2/pull/3145
- DataMan/GCC10 fix: https://github.com/ornladios/ADIOS2/pull/3155

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
