### PR TITLE
Re-Enable Install tests

### DIFF
--- a/recipe/build-libadios.sh
+++ b/recipe/build-libadios.sh
@@ -74,7 +74,7 @@ cmake               \
     -DPython_INCLUDE_DIR="$(${PYTHON} -c "from sysconfig import get_paths as gp; print(gp()['include'])")" \
     -DPNG_PNG_INCLUDE_DIR="${PREFIX}"
 
-cmake --build build "-j$((CPU_COUNT*2))" -v
+cmake --build build "-j$CPU_COUNT" -v
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" && "${RUN_TESTS}" == "ON" ]]
 then

--- a/recipe/build-libadios.sh
+++ b/recipe/build-libadios.sh
@@ -74,7 +74,7 @@ cmake               \
     -DPython_INCLUDE_DIR="$(${PYTHON} -c "from sysconfig import get_paths as gp; print(gp()['include'])")" \
     -DPNG_PNG_INCLUDE_DIR="${PREFIX}"
 
-cmake --build build "-j$CPU_COUNT" -v
+cmake --build build "-j${CPU_COUNT}" -v
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" && "${RUN_TESTS}" == "ON" ]]
 then

--- a/recipe/build-libadios.sh
+++ b/recipe/build-libadios.sh
@@ -74,7 +74,7 @@ cmake               \
     -DPython_INCLUDE_DIR="$(${PYTHON} -c "from sysconfig import get_paths as gp; print(gp()['include'])")" \
     -DPNG_PNG_INCLUDE_DIR="${PREFIX}"
 
-cmake --build build "-j${CPU_COUNT}" -v
+cmake --build build "-j$((CPU_COUNT*2))" -v
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" && "${RUN_TESTS}" == "ON" ]]
 then

--- a/recipe/build-libadios.sh
+++ b/recipe/build-libadios.sh
@@ -56,7 +56,6 @@ cmake               \
     -DADIOS2_BUILD_EXAMPLES=OFF               \
     -DADIOS2_HAVE_ZFP_CUDA=OFF                \
     -DADIOS2_INSTALL_GENERATE_CONFIG=OFF      \
-    -DADIOS2_RUN_INSTALL_TEST=OFF             \
     -DADIOS2_RUN_INSTALL_TEST=ON              \
     -DADIOS2_USE_BZip2=ON                     \
     -DADIOS2_USE_HDF5=ON                      \

--- a/recipe/build-libadios.sh
+++ b/recipe/build-libadios.sh
@@ -53,9 +53,11 @@ cmake               \
     -S "${SRC_DIR}" \
     -B build        \
     -GNinja         \
-    -DCMAKE_BUILD_TYPE=Release                \
-    -DBUILD_SHARED_LIBS=ON                    \
-    -DBUILD_TESTING=${RUN_TESTS}              \
+    -DADIOS2_BUILD_EXAMPLES=OFF               \
+    -DADIOS2_HAVE_ZFP_CUDA=OFF                \
+    -DADIOS2_INSTALL_GENERATE_CONFIG=OFF      \
+    -DADIOS2_RUN_INSTALL_TEST=OFF             \
+    -DADIOS2_RUN_INSTALL_TEST=ON              \
     -DADIOS2_USE_BZip2=ON                     \
     -DADIOS2_USE_HDF5=ON                      \
     -DADIOS2_USE_MPI=${USE_MPI}               \
@@ -63,13 +65,13 @@ cmake               \
     -DADIOS2_USE_Python=ON                    \
     -DADIOS2_USE_ZeroMQ=ON                    \
     -DADIOS2_USE_ZFP=ON                       \
-    -DADIOS2_HAVE_ZFP_CUDA=OFF                \
-    -DADIOS2_BUILD_EXAMPLES=OFF               \
-    -DADIOS2_RUN_INSTALL_TEST=OFF             \
-    -DPython_EXECUTABLE:FILEPATH="${PYTHON}"  \
-    -DPython_INCLUDE_DIR="$(${PYTHON} -c "from sysconfig import get_paths as gp; print(gp()['include'])")" \
+    -DBUILD_SHARED_LIBS=ON                    \
+    -DBUILD_TESTING=${RUN_TESTS}              \
+    -DCMAKE_BUILD_TYPE=Release                \
     -DCMAKE_INSTALL_LIBDIR=lib                \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}"        \
+    -DPython_EXECUTABLE:FILEPATH="${PYTHON}"  \
+    -DPython_INCLUDE_DIR="$(${PYTHON} -c "from sysconfig import get_paths as gp; print(gp()['include'])")" \
     -DPNG_PNG_INCLUDE_DIR="${PREFIX}"
 
 cmake --build build "-j${CPU_COUNT}" -v
@@ -78,6 +80,10 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" && "${RUN_TESTS}" == "ON" ]]
 then
     # SST: Flaky tests
     exclude_tests="SST"
+    # Disable the Makefile install test since it relies on the adios2-config
+    # script which is not being build anyways since it is being flaky in
+    # several configurations.
+    exclude_tests+="|Install.Make.*"
     if [[ "${target_platform}" =~ osx ]]
     then
         exclude_tests+="|Test.Engine.DataMan1D.Serial"


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged) - not needed, we do not want to deploy a new artifact
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This enables the cmake install tests and in Linux/OSX keeps disabled the Makefile install test, in addition to that it disables the generation of the `adios2-config` script which as seen in the Makefile tests failures, it incorrectly deliver the {C/CXX}FLAGS values, this script obtain those values by reversing engineering a dummy CMake project, for some cmake versions/platforms it fails to obtain them correctly. For the time being, I think that it is better not to provide this script as opposed to provide a bogus version of it.

In windows it still works so no reason to disable it.

<!--
Please add any other relevant info below:
-->
