### PR TITLE
install adios2_core first

### DIFF
--- a/recipe/build-libadios.bat
+++ b/recipe/build-libadios.bat
@@ -51,16 +51,16 @@ if errorlevel 1 exit 1
 :: Install everything but tools and scripts
 ::   see "make list_install_components"
 
+cmake --install build --component adios2_core-config
+cmake --install build --component adios2_core-development
+cmake --install build --component adios2_core-libraries
+cmake --install build --component adios2_core-runtime
 cmake --install build --component adios2_atl-development
 cmake --install build --component adios2_atl-libraries
 cmake --install build --component adios2_atl-runtime
 cmake --install build --component adios2_c-development
 cmake --install build --component adios2_c-libraries
 cmake --install build --component adios2_c-runtime
-cmake --install build --component adios2_core-config
-cmake --install build --component adios2_core-development
-cmake --install build --component adios2_core-libraries
-cmake --install build --component adios2_core-runtime
 cmake --install build --component adios2_cxx11-development
 cmake --install build --component adios2_cxx11-libraries
 cmake --install build --component adios2_cxx11-runtime

--- a/recipe/build-libadios.sh
+++ b/recipe/build-libadios.sh
@@ -97,15 +97,16 @@ fi
 
 # Install everything but tools and scripts
 #   see "make list_install_components"
+# core-config seems to need to be first, because it can _remove_ other cmake files
+cmake --install build --component adios2_core-config
+cmake --install build --component adios2_core-development
+cmake --install build --component adios2_core-libraries
+cmake --install build --component adios2_core-runtime
 cmake --install build --component adios2_atl-development
 cmake --install build --component adios2_atl-libraries
 cmake --install build --component adios2_c-development
 cmake --install build --component adios2_c-libraries
 cmake --install build --component adios2_c-runtime
-cmake --install build --component adios2_core-config
-cmake --install build --component adios2_core-development
-cmake --install build --component adios2_core-libraries
-cmake --install build --component adios2_core-runtime
 cmake --install build --component adios2_cxx11-development
 cmake --install build --component adios2_cxx11-libraries
 cmake --install build --component adios2_cxx11-runtime

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -111,7 +111,7 @@ outputs:
       files:
         - test-libadios.sh
       source_files:
-        - examples/hello
+        - examples/hello/helloWorld
       commands:
         - test -f ${PREFIX}/lib/cmake/adios2/adios2-config.cmake                      # [unix]
         - test -f ${PREFIX}/lib/cmake/adios2/adios2-c-targets.cmake                   # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "adios2" %}
 {% set version = "2.10.0" %}
 {% set sha256 = "e5984de488bda546553dd2f46f047e539333891e63b9fe73944782ba6c2d95e4" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
@@ -103,18 +103,35 @@ outputs:
         - {{ mpi }}  # [mpi != 'nompi']
 
     test:
+      requires:
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
+        - cmake
+        - make  # [unix]
+      files:
+        - test-libadios.sh
+      source_files:
+        - examples/hello
       commands:
         - test -f ${PREFIX}/lib/cmake/adios2/adios2-config.cmake                      # [unix]
-        - test -f ${PREFIX}/lib/libadios2_cxx11.so                                    # [linux]
-        - otool -L ${PREFIX}/lib/libadios2_cxx11.dylib                                # [osx]
+        - test -f ${PREFIX}/lib/cmake/adios2/adios2-c-targets.cmake                   # [unix]
+        - test -f ${PREFIX}/lib/cmake/adios2/adios2-cxx11-targets.cmake               # [unix]
+        - test -f ${PREFIX}/lib/libadios2_cxx11${SHLIB_EXT}                           # [unix]
+        - test -f ${PREFIX}/lib/libadios2_c${SHLIB_EXT}                               # [unix]
         - if exist %LIBRARY_PREFIX%\bin\adios2_cxx11.dll (exit 0) else (exit 1)       # [win]
+        - if exist %LIBRARY_PREFIX%\bin\adios2_c.dll (exit 0) else (exit 1)           # [win]
         - if exist %LIBRARY_PREFIX%\lib\cmake\adios2\adios2-config.cmake (exit 0) else (exit 1)  # [win]
+        - if exist %LIBRARY_PREFIX%\lib\cmake\adios2\adios2-c-targets.cmake (exit 0) else (exit 1)  # [win]
+        - if exist %LIBRARY_PREFIX%\lib\cmake\adios2\adios2-cxx11-targets.cmake (exit 0) else (exit 1)  # [win]
 
         # make sure we didn't install Python files
         - test ! -d ${SP_DIR}/adios2  # [unix]
         - if exist %SP_DIR%\adios2 (exit 1) else (exit 0)  # [win]
         - test ! -f ${PREFIX}/bin/bp5dbg  # [unix]
         - if exist %LIBRARY_PREFIX%\bin\bp5dbg (exit 1) else (exit 0)  # [win]
+        
+        # run a test build from the examples
+        - bash test-libadios.sh  # [unix]
 
   - name: adios2
     # Install tools and script built in the libadios2 pkg

--- a/recipe/test-libadios.sh
+++ b/recipe/test-libadios.sh
@@ -1,0 +1,21 @@
+set -ex
+
+export OMPI_ALLOW_RUN_AS_ROOT=1
+export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+export OMPI_MCA_rmaps_base_oversubscribe=1
+export OMPI_MCA_plm=isolated
+export OMPI_MCA_btl=tcp,self
+export OMPI_MCA_btl_vader_single_copy_mechanism=none
+
+cd examples/hello
+
+cmake $CMAKE_ARGS -B ./build
+cmake --build ./build
+
+for name in adios2_hello_helloWorld_c adios2_hello_helloWorld adios2_hello_helloWorld_hl; do
+  echo $name
+  ./build/$name
+  if [[ "$mpi" != "nompi" ]]; then
+    ./build/${name}_mpi
+  fi
+done

--- a/recipe/test-libadios.sh
+++ b/recipe/test-libadios.sh
@@ -7,7 +7,7 @@ export OMPI_MCA_plm=isolated
 export OMPI_MCA_btl=tcp,self
 export OMPI_MCA_btl_vader_single_copy_mechanism=none
 
-cd examples/hello
+cd examples/hello/helloWorld
 
 cmake $CMAKE_ARGS -B ./build
 cmake --build ./build


### PR DESCRIPTION
installing core seems to remove cmake target files installed before it, so make sure it's installed first.

I presume this is a cmake bug? Or it may be something in adios2 install logic to initialize the cmake directory. I'm not sure.

The missing files are resulting in `FindPackage(ADIOS2 REQUIRED)` failing with missing component: C.

adds a cmake test to check that it can be found, which should fail if this doesn't fix it.
