### PR TITLE
fix build/run dependencies, restore hdf5 pin

### DIFF
--- a/.ci_support/linux_64_mpimpichnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy2.0python3.10.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpimpichnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy2.0python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpimpichnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy2.0python3.11.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpimpichnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy2.0python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpimpichnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy2.0python3.12.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpimpichnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy2.0python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpimpichnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy2.0python3.9.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpimpichnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy2.0python3.9.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpimpichnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy2python3.13.____cp313.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpimpichnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy2python3.13.____cp313.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpinompinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy2.0python3.10.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpinompinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy2.0python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpinompinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy2.0python3.11.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpinompinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy2.0python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpinompinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy2.0python3.12.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpinompinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy2.0python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpinompinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy2.0python3.9.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpinompinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy2.0python3.9.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpinompinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_mpinompinumpy2python3.13.____cp313.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpinompinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_mpinompinumpy2python3.13.____cp313.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_64_mpiopenmpinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy2python3.13.____cp313.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy2python3.13.____cp313.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.10.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.11.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.12.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.9.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy2.0python3.9.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpimpichnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy2python3.13.____cp313.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpimpichnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy2python3.13.____cp313.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpinompinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy2.0python3.10.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpinompinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy2.0python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpinompinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy2.0python3.11.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpinompinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy2.0python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpinompinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy2.0python3.12.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpinompinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy2.0python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpinompinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy2.0python3.9.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpinompinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy2.0python3.9.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpinompinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy2python3.13.____cp313.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpinompinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy2python3.13.____cp313.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy2python3.13.____cp313.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy2python3.13.____cp313.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.10.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.11.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.12.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.9.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy2.0python3.9.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy2python3.13.____cp313.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy2python3.13.____cp313.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.10.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.11.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.12.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.9.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy2.0python3.9.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpinompinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy2python3.13.____cp313.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpinompinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy2python3.13.____cp313.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.10.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.11.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.12.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.9.____cpython.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy2.0python3.9.____cpython.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy2python3.13.____cp313.yaml
@@ -50,6 +50,10 @@ python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+ucx:
+- '1.18'
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy2python3.13.____cp313.yaml
@@ -26,6 +26,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/migrations/c_blosc2217.yaml
+++ b/.ci_support/migrations/c_blosc2217.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for c_blosc2 2.17
-  kind: version
-  migration_number: 1
-c_blosc2:
-- '2.17'
-migrator_ts: 1740624047.6984208

--- a/.ci_support/osx_64_mpimpichnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy2.0python3.10.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpimpichnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy2.0python3.10.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpimpichnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy2.0python3.11.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpimpichnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy2.0python3.11.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpimpichnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy2.0python3.12.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpimpichnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy2.0python3.12.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpimpichnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy2.0python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpimpichnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy2.0python3.9.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpimpichnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy2python3.13.____cp313.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpimpichnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy2python3.13.____cp313.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpinompinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy2.0python3.10.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpinompinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy2.0python3.10.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpinompinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy2.0python3.11.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpinompinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy2.0python3.11.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpinompinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy2.0python3.12.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpinompinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy2.0python3.12.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpinompinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy2.0python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpinompinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy2.0python3.9.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpinompinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_mpinompinumpy2python3.13.____cp313.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpinompinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_mpinompinumpy2python3.13.____cp313.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy2python3.13.____cp313.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_64_mpiopenmpinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy2python3.13.____cp313.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpimpichnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy2.0python3.10.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpimpichnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy2.0python3.10.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpimpichnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy2.0python3.11.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpimpichnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy2.0python3.11.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpimpichnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy2.0python3.12.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpimpichnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy2.0python3.12.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpimpichnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy2.0python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpimpichnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy2.0python3.9.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpimpichnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy2python3.13.____cp313.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpimpichnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy2python3.13.____cp313.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpinompinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy2.0python3.10.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpinompinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy2.0python3.10.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpinompinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy2.0python3.11.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpinompinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy2.0python3.11.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpinompinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy2.0python3.12.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpinompinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy2.0python3.12.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpinompinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy2.0python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpinompinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy2.0python3.9.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpinompinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy2python3.13.____cp313.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpinompinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy2python3.13.____cp313.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.10.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.11.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.12.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy2.0python3.9.____cpython.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy2python3.13.____cp313.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy2python3.13.____cp313.yaml
@@ -48,6 +48,8 @@ python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zeromq:
+- 4.3.5
 zfp:
 - '1.0'
 zip_keys:

--- a/.ci_support/win_64_numpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/win_64_numpy2.0python3.10.____cpython.yaml
@@ -12,6 +12,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/win_64_numpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/win_64_numpy2.0python3.11.____cpython.yaml
@@ -12,6 +12,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/win_64_numpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/win_64_numpy2.0python3.12.____cpython.yaml
@@ -12,6 +12,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/win_64_numpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy2.0python3.9.____cpython.yaml
@@ -12,6 +12,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.ci_support/win_64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/win_64_numpy2python3.13.____cp313.yaml
@@ -12,6 +12,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+hdf5:
+- 1.14.3
 libffi:
 - '3.4'
 libpng:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -140,6 +140,9 @@ outputs:
     # those in the actual build above which have relevant run_exports
     requirements:
       build:
+        - {{ compiler("c") }}
+        - {{ stdlib("c") }}
+        - {{ compiler("cxx") }}
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - numpy                                  # [build_platform != target_platform]
@@ -147,9 +150,12 @@ outputs:
       host:
         - {{ mpi }}  # [mpi != 'nompi']
         - {{ pin_subpackage("libadios2", exact=True) }}
+        - hdf5
         - python
         - mpi4py     # [mpi != 'nompi']
         - numpy
+        - ucx  # [linux and mpi != 'nompi']
+        - zfp
       run:
         - {{ pin_subpackage("libadios2", exact=True) }}
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ outputs:
       # note: all of these should be duplicated to host/build in adios2
       # to get the right pins
       ignore_run_exports_from:
-        - cross-python
+        - cross-python_{{ target_platform }}
         - python
         - mpi4py
         - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -92,7 +92,8 @@ outputs:
         - mpi4py     # [mpi != 'nompi']
         - numpy
         - python
-        - zeromq >=4.1  # [not win]
+        - zeromq  # [not win]
+        - ucx  # [linux and mpi != 'nompi']
         - zfp
         - zlib
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -151,6 +151,7 @@ outputs:
         - {{ mpi }}  # [mpi != 'nompi']
         - {{ pin_subpackage("libadios2", exact=True) }}
         - hdf5
+        - hdf5 * {{ mpi_prefix }}_*
         - python
         - mpi4py     # [mpi != 'nompi']
         - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "adios2" %}
 {% set version = "2.10.2" %}
 {% set sha256 = "14cf0bcd94772194bce0f2c0e74dba187965d1cffd12d45f801c32929158579e" %}
-{% set build = 4 %}
+{% set build = 5 %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
@@ -63,52 +63,38 @@ outputs:
         - {{ compiler('c') }}
         - {{ stdlib("c") }}
         - {{ compiler('cxx') }}
-                                              # TODO: seems incompatible on OSX and too experimental for Windows
+        # TODO: seems incompatible on OSX and too experimental for Windows
         - {{ compiler('fortran') }}           # [linux]
-        - {{ mpi }}                           # [mpi == 'openmpi']
         - bison                               # [unix]
-        - bzip2
-        - c-blosc2
         - cmake
-        - cross-python_{{ target_platform }}  # [build_platform != target_platform]
         - flex                                # [unix]
-        - hdf5 * {{ mpi_prefix }}_*
-        - libffi
-        - libpng
         - make                                # [unix]
         - ninja                               # [unix]
-        - numpy                               # [build_platform != target_platform]
         - pkg-config                          # [unix]
-        - python                              # [build_platform != target_platform]
-        - zeromq >=4.1                        # [not win]
-        - zfp
-        - zlib
 
+        # Cross compiliation
+        - {{ mpi }}                           # [mpi == 'openmpi' and build_platform != target_platform]
+        # Needed for Python cross:
+        # Python _build_ is handled here, install in separate output
+        - python                              # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+        - numpy                               # [build_platform != target_platform]
       host:
         - {{ mpi }}  # [mpi != 'nompi']
         - bzip2
         - c-blosc2
+        # need to list hdf5 twice to get version pinning from conda_build_config
+        - hdf5
         - hdf5 * {{ mpi_prefix }}_*
         - libffi
         - libpng
+        - libsodium  # [not win]
         - mpi4py     # [mpi != 'nompi']
         - numpy
         - python
         - zeromq >=4.1  # [not win]
         - zfp
         - zlib
-
-      run:
-        - {{ mpi }}  # [mpi != 'nompi']
-        - {{ pin_compatible('numpy') }}
-        - bzip2
-        - c-blosc2
-        - cmake
-        - libpng
-        - libzlib
-        - zeromq >=4.1  # [not win]
-        - zfp
-        - hdf5 * {{ mpi_prefix }}_*
 
     test:
       requires:
@@ -150,7 +136,7 @@ outputs:
         - {{ pin_subpackage('adios2', min_pin='x.x.x', max_pin='x.x.x') }} {{ mpi_prefix }}_*
 
     # below requirements should match exactly
-    # those in the actual build above
+    # those in the actual build above which have relevant run_exports
     requirements:
       build:
         - python                                 # [build_platform != target_platform]
@@ -164,11 +150,8 @@ outputs:
         - mpi4py     # [mpi != 'nompi']
         - numpy
       run:
-        - {{ mpi }}  # [mpi != 'nompi']
         - {{ pin_subpackage("libadios2", exact=True) }}
         - python
-        - mpi4py     # [mpi != 'nompi']
-        - numpy
     test:
       # test.imports is unreliable for multiple outputs
       commands:


### PR DESCRIPTION
I'm not sure of the reasoning behind it since there's no discussion, but it looks like #107 added what appear to be quite a few incorrect dependencies and removed some required ones and the comments explaining why they were necessary. The most important one was `hdf5`, which has lost its pinning as a result, as revealed by the `rerender` here. In particular:

- remove host dependencies from the build environment. The build environment should only have _build_ tools (compilers, etc.), and occasionally some dependencies needed during cross compilation.
- remove redundant `run` dependency on packages with `run_exports`. The only dependencies that need to be in `run` are those that _do not_ have `run_exports`, need different/stricter pinning than run_exports, or are not build-time dependencies at all.
- restore grouping of cross-compile dependencies in the build env
- removed `cmake` from runtime dependencies, added in #107
- add missing `libsodium` dependency to host, found during link check:

```
WARNING (libadios2,lib/libEncryptionOperator.so): Needed DSO lib/libsodium.26.dylib found in ['conda-forge/osx-arm64::libsodium==1.0.20=h99b78c6_0']
WARNING (libadios2,lib/libEncryptionOperator.so): .. but ['conda-forge/osx-arm64::libsodium==1.0.20=h99b78c6_0'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
```
